### PR TITLE
Merge 'source-synchronization' into 'dev'

### DIFF
--- a/src/time-machine/App.tsx
+++ b/src/time-machine/App.tsx
@@ -50,6 +50,9 @@ export function App(): JSX.Element {
 
   const [selectedFishIndex, setSelectedFishIndex] = useState<number>(0)
   const [selectedTags, setSelectedTags] = React.useState(whereToTagsString(importedFishes[0].where))
+  const [selectedSyncCheckbox, setSelectedSyncCheckbox] = React.useState<{
+    readonly [x: string]: boolean
+  }>({})
 
   const [calculatingOffsetLimits, setCalculatingOffsetLimits] = React.useState<boolean>(false)
   const [calculatingFishState, setCalculatingFishState] = React.useState<boolean>(false)
@@ -227,9 +230,14 @@ export function App(): JSX.Element {
                         sid={sid}
                         numberOfSelectedEvents={selectedEvents[sid] + 1 || 0}
                         numberOfAllEvents={events + 1}
+                        syncDisabled={false}
+                        syncSelected={selectedSyncCheckbox[sid] || false}
                         onEventsChanged={(events) => {
                           setSelectedEvents(upsertOffsetMapValue(selectedEvents, sid, events - 1))
                         }}
+                        onSyncCheckboxChanged={(checked) =>
+                          setSelectedSyncCheckbox({ ...selectedSyncCheckbox, [sid]: checked })
+                        }
                         disabled={calculatingFishState || calculatingOffsetLimits}
                         key={sid}
                       />

--- a/src/time-machine/App.tsx
+++ b/src/time-machine/App.tsx
@@ -235,7 +235,6 @@ export function App(): JSX.Element {
                         sid={sid}
                         numberOfSelectedEvents={selectedEvents[sid] + 1 || 0}
                         numberOfAllEvents={events + 1}
-                        syncDisabled={disabled}
                         syncSelected={selectedSyncCheckboxesMap[sid] || false}
                         onEventsChanged={(events) => {
                           if (selectedSyncCheckboxesMap[sid]) {
@@ -328,7 +327,7 @@ export function App(): JSX.Element {
         selectedTimeLimitMicros,
         pond,
       )
-      newOffsets = upsertOffsetMapValue(newOffsets, sid, selectedOffset === -1 ? 0 : selectedOffset)
+      newOffsets = upsertOffsetMapValue(newOffsets, sid, selectedOffset)
     }
     setSelectableEvents(newOffsets)
     setCalculatingOffsetLimits(false)

--- a/src/time-machine/App.tsx
+++ b/src/time-machine/App.tsx
@@ -50,9 +50,10 @@ export function App(): JSX.Element {
 
   const [selectedFishIndex, setSelectedFishIndex] = useState<number>(0)
   const [selectedTags, setSelectedTags] = React.useState(whereToTagsString(importedFishes[0].where))
-  const [selectedSyncCheckbox, setSelectedSyncCheckbox] = React.useState<{
+  const [selectedSyncCheckboxesMap, setSelectedSyncCheckbox] = React.useState<{
     readonly [x: string]: boolean
   }>({})
+  const [checkboxLock, setCheckboxLock] = useState<boolean>(false)
 
   const [calculatingOffsetLimits, setCalculatingOffsetLimits] = React.useState<boolean>(false)
   const [calculatingFishState, setCalculatingFishState] = React.useState<boolean>(false)
@@ -230,14 +231,15 @@ export function App(): JSX.Element {
                         sid={sid}
                         numberOfSelectedEvents={selectedEvents[sid] + 1 || 0}
                         numberOfAllEvents={events + 1}
-                        syncDisabled={false}
-                        syncSelected={selectedSyncCheckbox[sid] || false}
+                        syncDisabled={!selectedSyncCheckboxesMap[sid] && checkboxLock}
+                        syncSelected={selectedSyncCheckboxesMap[sid] || false}
                         onEventsChanged={(events) => {
                           setSelectedEvents(upsertOffsetMapValue(selectedEvents, sid, events - 1))
                         }}
-                        onSyncCheckboxChanged={(checked) =>
-                          setSelectedSyncCheckbox({ ...selectedSyncCheckbox, [sid]: checked })
-                        }
+                        onSyncCheckboxChanged={(checked) => {
+                          setSelectedSyncCheckbox({ ...selectedSyncCheckboxesMap, [sid]: checked })
+                          setCheckboxLock(checked)
+                        }}
                         disabled={calculatingFishState || calculatingOffsetLimits}
                         key={sid}
                       />

--- a/src/time-machine/components/SourceSlider.tsx
+++ b/src/time-machine/components/SourceSlider.tsx
@@ -7,7 +7,6 @@ type SourceSliderProps = {
   numberOfAllEvents: number
   disabled: boolean
   syncSelected: boolean
-  syncDisabled: boolean
   onEventsChanged: (events: number) => void
   onSyncCheckboxChanged: (checked: boolean) => void
 }
@@ -20,7 +19,6 @@ export function SourceSlider({
   onEventsChanged,
   onSyncCheckboxChanged,
   syncSelected,
-  syncDisabled,
 }: SourceSliderProps): JSX.Element {
   const [sliderValue, setSliderValue] = useState<number>(numberOfSelectedEvents)
 
@@ -58,7 +56,7 @@ export function SourceSlider({
           onChange={(event) => {
             onSyncCheckboxChanged(event.target.checked)
           }}
-          disabled={syncDisabled}
+          disabled={disabled}
           color="primary"
           inputProps={{ 'aria-label': 'primary checkbox' }}
         />

--- a/src/time-machine/components/SourceSlider.tsx
+++ b/src/time-machine/components/SourceSlider.tsx
@@ -1,4 +1,4 @@
-import { Slider, Typography, Grid } from '@material-ui/core'
+import { Slider, Typography, Grid, Checkbox } from '@material-ui/core'
 import React, { useState } from 'react'
 
 type SourceSliderProps = {
@@ -6,7 +6,10 @@ type SourceSliderProps = {
   numberOfSelectedEvents: number
   numberOfAllEvents: number
   disabled: boolean
+  syncSelected: boolean
+  syncDisabled: boolean
   onEventsChanged: (events: number) => void
+  onSyncCheckboxChanged: (checked: boolean) => void
 }
 
 export function SourceSlider({
@@ -15,6 +18,9 @@ export function SourceSlider({
   numberOfAllEvents,
   disabled,
   onEventsChanged,
+  onSyncCheckboxChanged,
+  syncSelected,
+  syncDisabled,
 }: SourceSliderProps): JSX.Element {
   const [sliderValue, setSliderValue] = useState<number>(numberOfSelectedEvents)
 
@@ -29,7 +35,7 @@ export function SourceSlider({
           {sid} <br />({numberOfSelectedEvents}/{numberOfAllEvents})
         </Typography>
       </Grid>
-      <Grid item xs={10}>
+      <Grid item xs={8}>
         <Slider
           style={{ maxWidth: 350 }}
           value={sliderValue}
@@ -43,6 +49,18 @@ export function SourceSlider({
             onEventsChanged(+value)
           }}
           aria-labelledby="continuous-slider"
+        />
+      </Grid>
+      <Grid>
+        <Typography>Sync</Typography>
+        <Checkbox
+          checked={syncSelected}
+          onChange={(event) => {
+            onSyncCheckboxChanged(event.target.checked)
+          }}
+          disabled={syncDisabled}
+          color="primary"
+          inputProps={{ 'aria-label': 'primary checkbox' }}
         />
       </Grid>
     </Grid>

--- a/test/time-machine/actyx-functions.test.ts
+++ b/test/time-machine/actyx-functions.test.ts
@@ -148,6 +148,25 @@ describe('reduceTwinStateFromEvents', () => {
   })
 })
 
+describe('syncSelectedEventsOnTimestamp', () => {
+  let testPond: Pond
+  beforeAll(() => {
+    testPond = createAlternatingSourceTestPond(2, 2)
+  })
+  afterAll(() => {
+    testPond.dispose()
+  })
+  it('should give the offset of the event the happened before the given timestamp for each source', async () => {
+    const offsets = await actyxFunc.syncOffsetMapOnTimestamp(
+      BASE_DATE + 2,
+      await testPond.events().currentOffsets(),
+      testPond,
+    )
+    expect(offsets['source_0']).toBe(1)
+    expect(offsets['source_1']).toBe(0)
+  })
+})
+
 function getTestEvents(): ActyxEvent[] {
   const events: ActyxEvent[] = []
   events.push(createTestEvent({ eventType: 'stateOneToTwo' }))


### PR DESCRIPTION
Added functionality for synchronizing all sources to the event of a single source. The user selects a source to sync, so all other sources only include events that occured prior to the selected event of the synced source. 